### PR TITLE
Update Spring Boot parent version to 3.3.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.6</version>
+        <version>3.3.7</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>guru.springframework</groupId>


### PR DESCRIPTION
Upgraded the Spring Boot starter parent from version 3.3.6 to 3.3.7 to incorporate the latest bug fixes and improvements. This helps ensure the project remains up-to-date with the latest stable release.